### PR TITLE
Feat/lib refactor

### DIFF
--- a/sqlDB_example_test.go
+++ b/sqlDB_example_test.go
@@ -1,4 +1,4 @@
-package sqlproxy
+package sqldb
 
 import (
 	"database/sql"

--- a/sqlDB_test.go
+++ b/sqlDB_test.go
@@ -1,4 +1,4 @@
-package sqlproxy
+package sqldb
 
 import (
 	"database/sql"

--- a/sqlHelpers.go
+++ b/sqlHelpers.go
@@ -1,4 +1,4 @@
-package sqlproxy
+package sqldb
 
 type DBEngine string
 

--- a/sqlProxy.go
+++ b/sqlProxy.go
@@ -9,14 +9,14 @@ import (
 	"github.com/cdleo/go-commons/sqlcommons"
 )
 
-type sqlProxy struct {
+type SQLProxy struct {
 	connector  sqlcommons.SQLConnector
 	translator sqlcommons.SQLAdapter
 	logger     logger.Logger
 	db         *sql.DB
 }
 
-func (s *sqlProxy) Open() (*sql.DB, error) {
+func (s *SQLProxy) Open() (*sql.DB, error) {
 	if db, err := s.connector.Open(s.logger, s.translator); err != nil {
 		return nil, s.translator.ErrorHandler(err)
 	} else {
@@ -26,7 +26,7 @@ func (s *sqlProxy) Open() (*sql.DB, error) {
 	return s.db, nil
 }
 
-func (s *sqlProxy) IsOpen() error {
+func (s *SQLProxy) IsOpen() error {
 	if s.db == nil {
 		return sqlcommons.DBNotInitialized
 	}
@@ -47,7 +47,7 @@ func (s *sqlProxy) IsOpen() error {
 	return nil
 }
 
-func (s *sqlProxy) Close() error {
+func (s *SQLProxy) Close() error {
 
 	if s.db == nil {
 		return sqlcommons.DBNotInitialized
@@ -58,7 +58,7 @@ func (s *sqlProxy) Close() error {
 	return err
 }
 
-func (s *sqlProxy) GetNextSequenceValue(ctx context.Context, sequenceName string) (int64, error) {
+func (s *SQLProxy) GetNextSequenceValue(ctx context.Context, sequenceName string) (int64, error) {
 	if err := s.IsOpen(); err != nil {
 		return 0, sqlcommons.ConnectionClosed
 	}

--- a/sqlProxy.go
+++ b/sqlProxy.go
@@ -1,4 +1,4 @@
-package sqlproxy
+package sqldb
 
 import (
 	"context"

--- a/sqlProxyBuilder.go
+++ b/sqlProxyBuilder.go
@@ -1,4 +1,4 @@
-package sqlproxy
+package sqldb
 
 import (
 	"github.com/cdleo/go-commons/logger"

--- a/sqlProxyBuilder.go
+++ b/sqlProxyBuilder.go
@@ -6,13 +6,13 @@ import (
 	"github.com/cdleo/go-sqldb/adapter"
 )
 
-type sqlProxyBuilder struct {
-	proxy sqlProxy
+type SQLProxyBuilder struct {
+	proxy SQLProxy
 }
 
-func NewSQLProxyBuilder(connector sqlcommons.SQLConnector) *sqlProxyBuilder {
-	return &sqlProxyBuilder{
-		proxy: sqlProxy{
+func NewSQLProxyBuilder(connector sqlcommons.SQLConnector) *SQLProxyBuilder {
+	return &SQLProxyBuilder{
+		proxy: SQLProxy{
 			connector:  connector,
 			translator: adapter.NewNoopAdapter(),
 			logger:     logger.NewNoLogLogger(),
@@ -21,16 +21,16 @@ func NewSQLProxyBuilder(connector sqlcommons.SQLConnector) *sqlProxyBuilder {
 	}
 }
 
-func (s *sqlProxyBuilder) WithAdapter(translator sqlcommons.SQLAdapter) *sqlProxyBuilder {
+func (s *SQLProxyBuilder) WithAdapter(translator sqlcommons.SQLAdapter) *SQLProxyBuilder {
 	s.proxy.translator = translator
 	return s
 }
 
-func (s *sqlProxyBuilder) WithLogger(logger logger.Logger) *sqlProxyBuilder {
+func (s *SQLProxyBuilder) WithLogger(logger logger.Logger) *SQLProxyBuilder {
 	s.proxy.logger = logger
 	return s
 }
 
-func (s *sqlProxyBuilder) Build() *sqlProxy {
+func (s *SQLProxyBuilder) Build() *SQLProxy {
 	return &s.proxy
 }


### PR DESCRIPTION
New verison of the library

After this refactor, it's not more needed the sqlDB wrapper and the proxy allows the use of the standard *sql.DB package 